### PR TITLE
設定画面を追加

### DIFF
--- a/ios/Genesis/ARViewContainer.swift
+++ b/ios/Genesis/ARViewContainer.swift
@@ -62,10 +62,10 @@ struct ARViewContainer: UIViewRepresentable {
         var isTurningLeft: Bool = false
         var isTurningRight: Bool = false
 
-        private let maxSpeed: Float = 0.2
-        private let acceleration: Float = 0.005
-        private let deceleration: Float = 0.02
-        private let rotationSpeed: Float = 0.05
+        private var maxSpeed: Float { Float(AppSettings.shared.maxSpeed) }
+        private var acceleration: Float { Float(AppSettings.shared.acceleration) }
+        private var deceleration: Float { acceleration * 4 }
+        private var rotationSpeed: Float { Float(AppSettings.shared.steeringSensitivity) }
 
         func session(_ session: ARSession, didFailWithError error: Error) {
             print("❌ ARSession エラー: \(error.localizedDescription)")

--- a/ios/Genesis/AppSettings.swift
+++ b/ios/Genesis/AppSettings.swift
@@ -1,0 +1,51 @@
+//
+//  Settings.swift
+//  Genesis
+//
+//  Created by jumpei ono on 2026/03/20.
+//
+
+import Foundation
+import Combine
+
+/// アプリ全体の設定を管理するクラス
+class AppSettings: ObservableObject {
+    static let shared = AppSettings()
+
+    /// ステアリング感度（0.01〜0.1）
+    @Published var steeringSensitivity: Double {
+        didSet { UserDefaults.standard.set(steeringSensitivity, forKey: "steeringSensitivity") }
+    }
+
+    /// 最大速度（0.05〜0.5）
+    @Published var maxSpeed: Double {
+        didSet { UserDefaults.standard.set(maxSpeed, forKey: "maxSpeed") }
+    }
+
+    /// 加速度（0.001〜0.02）
+    @Published var acceleration: Double {
+        didSet { UserDefaults.standard.set(acceleration, forKey: "acceleration") }
+    }
+
+    private init() {
+        let defaults = UserDefaults.standard
+
+        // 初回起動時のデフォルト値を登録
+        defaults.register(defaults: [
+            "steeringSensitivity": 0.05,
+            "maxSpeed": 0.2,
+            "acceleration": 0.005
+        ])
+
+        self.steeringSensitivity = defaults.double(forKey: "steeringSensitivity")
+        self.maxSpeed = defaults.double(forKey: "maxSpeed")
+        self.acceleration = defaults.double(forKey: "acceleration")
+    }
+
+    /// デフォルト値にリセット
+    func resetToDefaults() {
+        steeringSensitivity = 0.05
+        maxSpeed = 0.2
+        acceleration = 0.005
+    }
+}

--- a/ios/Genesis/SettingsView.swift
+++ b/ios/Genesis/SettingsView.swift
@@ -1,0 +1,73 @@
+//
+//  SettingsView.swift
+//  Genesis
+//
+//  Created by jumpei ono on 2026/03/20.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject private var settings = AppSettings.shared
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("操作") {
+                    VStack(alignment: .leading) {
+                        HStack {
+                            Text("ステアリング感度")
+                            Spacer()
+                            Text(String(format: "%.2f", settings.steeringSensitivity))
+                                .foregroundColor(.secondary)
+                        }
+                        Slider(value: $settings.steeringSensitivity, in: 0.01...0.1, step: 0.01)
+                    }
+                }
+
+                Section("走行") {
+                    VStack(alignment: .leading) {
+                        HStack {
+                            Text("最大速度")
+                            Spacer()
+                            Text(String(format: "%.2f", settings.maxSpeed))
+                                .foregroundColor(.secondary)
+                        }
+                        Slider(value: $settings.maxSpeed, in: 0.05...0.5, step: 0.05)
+                    }
+
+                    VStack(alignment: .leading) {
+                        HStack {
+                            Text("加速度")
+                            Spacer()
+                            Text(String(format: "%.3f", settings.acceleration))
+                                .foregroundColor(.secondary)
+                        }
+                        Slider(value: $settings.acceleration, in: 0.001...0.02, step: 0.001)
+                    }
+                }
+
+                Section {
+                    Button("デフォルトに戻す") {
+                        settings.resetToDefaults()
+                    }
+                    .foregroundColor(.red)
+                }
+            }
+            .navigationTitle("設定")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("閉じる") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/ios/Genesis/TitleView.swift
+++ b/ios/Genesis/TitleView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct TitleView: View {
     @State private var isShowingAR = false
+    @State private var isShowingSettings = false
     @State private var titleOpacity: Double = 0
     @State private var buttonOpacity: Double = 0
 
@@ -60,8 +61,23 @@ struct TitleView: View {
                 }
                 .opacity(buttonOpacity)
 
+                // 設定ボタン
+                Button {
+                    isShowingSettings = true
+                } label: {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 20))
+                        .foregroundColor(.white.opacity(0.6))
+                        .frame(width: 48, height: 48)
+                        .background(
+                            Circle()
+                                .stroke(Color.white.opacity(0.3), lineWidth: 1)
+                        )
+                }
+                .opacity(buttonOpacity)
+
                 Spacer()
-                    .frame(height: 80)
+                    .frame(height: 40)
             }
         }
         .onAppear {
@@ -74,6 +90,9 @@ struct TitleView: View {
         }
         .fullScreenCover(isPresented: $isShowingAR) {
             ContentView()
+        }
+        .sheet(isPresented: $isShowingSettings) {
+            SettingsView()
         }
     }
 }


### PR DESCRIPTION
## Summary
- タイトル画面に歯車アイコンの設定ボタンを追加
- ステアリング感度・最大速度・加速度をスライダーで調整可能に
- UserDefaultsで設定を永続化、デフォルトリセット機能付き
- ARViewContainerのハードコード値をAppSettingsから読むように変更

## Test plan
- [ ] タイトル画面の歯車ボタンから設定画面が開くこと
- [ ] 各スライダーで値が変更できること
- [ ] 設定変更がAR画面の操作感に反映されること
- [ ] アプリ再起動後も設定が保持されること
- [ ] 「デフォルトに戻す」で初期値に戻ること

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)