### PR TITLE
エラーハンドリングUIを追加

### DIFF
--- a/ios/Genesis/ARViewContainer.swift
+++ b/ios/Genesis/ARViewContainer.swift
@@ -8,6 +8,7 @@ struct ARViewContainer: UIViewRepresentable {
     @Binding var isTurningLeft: Bool
     @Binding var isTurningRight: Bool
     @Binding var hasPlacedCar: Bool
+    @Binding var errorMessage: String?
 
     func makeUIView(context: Context) -> ARView {
         let arView = ARView(frame: .zero)
@@ -35,6 +36,7 @@ struct ARViewContainer: UIViewRepresentable {
         context.coordinator.isTurningLeft = isTurningLeft
         context.coordinator.isTurningRight = isTurningRight
         context.coordinator.hasPlacedCarBinding = $hasPlacedCar
+        context.coordinator.errorMessageBinding = $errorMessage
     }
 
     func makeCoordinator() -> Coordinator {
@@ -44,6 +46,7 @@ struct ARViewContainer: UIViewRepresentable {
     class Coordinator: NSObject, ARSessionDelegate {
         weak var arView: ARView?
         var hasPlacedCarBinding: Binding<Bool>?
+        var errorMessageBinding: Binding<String?>?
         private var hasPlacedCar = false
         private var carEntity: Entity?
         private var carAnchor: AnchorEntity?
@@ -68,8 +71,16 @@ struct ARViewContainer: UIViewRepresentable {
         private var deceleration: Float { acceleration * 4 }
         private var rotationSpeed: Float { Float(AppSettings.shared.steeringSensitivity) }
 
+        // エラーをUIに通知
+        private func reportError(_ message: String) {
+            print("❌ \(message)")
+            DispatchQueue.main.async {
+                self.errorMessageBinding?.wrappedValue = message
+            }
+        }
+
         func session(_ session: ARSession, didFailWithError error: Error) {
-            print("❌ ARSession エラー: \(error.localizedDescription)")
+            reportError("ARセッションエラー: \(error.localizedDescription)")
         }
 
         // 検知した平面をハイライト表示
@@ -145,7 +156,7 @@ struct ARViewContainer: UIViewRepresentable {
             guard let arView = arView else { return }
 
             guard let url = Bundle.main.url(forResource: "miniCooperbake", withExtension: "usdz") else {
-                print("❌ USDZファイルがバンドルに見つかりません")
+                reportError("車のモデルデータが見つかりません")
                 return
             }
 
@@ -173,7 +184,7 @@ struct ARViewContainer: UIViewRepresentable {
 
                 startAnimationTimer()
             } catch {
-                print("❌ USDZモデルの読み込みに失敗しました: \(error)")
+                reportError("車のモデル読み込みに失敗しました: \(error.localizedDescription)")
             }
         }
 

--- a/ios/Genesis/ContentView.swift
+++ b/ios/Genesis/ContentView.swift
@@ -5,6 +5,7 @@ struct ContentView: View {
     @State private var joystickX: Double = 0
     @State private var joystickY: Double = 0
     @State private var hasPlacedCar = false
+    @State private var errorMessage: String?
 
     private var isTurningLeft: Bool {
         joystickX < -0.3
@@ -21,7 +22,8 @@ struct ContentView: View {
                 isBraking: .constant(false),
                 isTurningLeft: .constant(isTurningLeft),
                 isTurningRight: .constant(isTurningRight),
-                hasPlacedCar: $hasPlacedCar
+                hasPlacedCar: $hasPlacedCar,
+                errorMessage: $errorMessage
             )
             .edgesIgnoringSafeArea(.all)
 
@@ -72,6 +74,14 @@ struct ContentView: View {
                     .padding(.bottom, 50)
                 }
             }
+        }
+        .alert("エラー", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK") { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
         }
     }
 }


### PR DESCRIPTION
## Summary
- ARセッションエラー・モデル未発見・読み込み失敗時にアラートダイアログで通知
- `print` のみだったエラーを `Binding` で `ContentView` に伝達する仕組みを追加
- ユーザーに分かりやすい日本語メッセージで表示

## Test plan
- [ ] ARセッションエラー時にアラートが表示されること
- [ ] アラートのOKボタンで閉じられること
- [ ] 正常動作時にアラートが出ないこと

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)