### PR TITLE
車選択画面を追加

### DIFF
--- a/ios/Genesis/AppSettings.swift
+++ b/ios/Genesis/AppSettings.swift
@@ -27,6 +27,16 @@ class AppSettings: ObservableObject {
         didSet { UserDefaults.standard.set(acceleration, forKey: "acceleration") }
     }
 
+    /// 選択中の車モデルID
+    @Published var selectedCarId: String {
+        didSet { UserDefaults.standard.set(selectedCarId, forKey: "selectedCarId") }
+    }
+
+    /// 選択中の車モデル
+    var selectedCar: CarModel {
+        CarModel.all.first { $0.id == selectedCarId } ?? CarModel.all[0]
+    }
+
     private init() {
         let defaults = UserDefaults.standard
 
@@ -34,12 +44,14 @@ class AppSettings: ObservableObject {
         defaults.register(defaults: [
             "steeringSensitivity": 0.05,
             "maxSpeed": 0.2,
-            "acceleration": 0.005
+            "acceleration": 0.005,
+            "selectedCarId": "mini_cooper"
         ])
 
         self.steeringSensitivity = defaults.double(forKey: "steeringSensitivity")
         self.maxSpeed = defaults.double(forKey: "maxSpeed")
         self.acceleration = defaults.double(forKey: "acceleration")
+        self.selectedCarId = defaults.string(forKey: "selectedCarId") ?? "mini_cooper"
     }
 
     /// デフォルト値にリセット
@@ -47,5 +59,6 @@ class AppSettings: ObservableObject {
         steeringSensitivity = 0.05
         maxSpeed = 0.2
         acceleration = 0.005
+        selectedCarId = "mini_cooper"
     }
 }

--- a/ios/Genesis/CarModel.swift
+++ b/ios/Genesis/CarModel.swift
@@ -1,0 +1,49 @@
+//
+//  CarModel.swift
+//  Genesis
+//
+//  Created by jumpei ono on 2026/03/20.
+//
+
+import Foundation
+
+/// 選択可能な車モデルの定義
+struct CarModel: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let description: String
+    let modelFileName: String
+    let emoji: String
+
+    /// 利用可能な車モデル一覧（モック）
+    static let all: [CarModel] = [
+        CarModel(
+            id: "mini_cooper",
+            name: "Mini Cooper",
+            description: "コンパクトでキビキビ走る街乗りの定番",
+            modelFileName: "miniCooperbake",
+            emoji: "🚗"
+        ),
+        CarModel(
+            id: "sports_car",
+            name: "スポーツカー",
+            description: "圧倒的な加速力とスピード",
+            modelFileName: "sports_car",
+            emoji: "🏎️"
+        ),
+        CarModel(
+            id: "suv",
+            name: "SUV",
+            description: "安定感抜群のオフロード仕様",
+            modelFileName: "suv",
+            emoji: "🚙"
+        ),
+        CarModel(
+            id: "truck",
+            name: "トラック",
+            description: "パワフルな大型車両",
+            modelFileName: "truck",
+            emoji: "🛻"
+        ),
+    ]
+}

--- a/ios/Genesis/CarSelectionView.swift
+++ b/ios/Genesis/CarSelectionView.swift
@@ -1,0 +1,59 @@
+//
+//  CarSelectionView.swift
+//  Genesis
+//
+//  Created by jumpei ono on 2026/03/20.
+//
+
+import SwiftUI
+
+struct CarSelectionView: View {
+    @Binding var selectedCarId: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List(CarModel.all) { car in
+            Button {
+                selectedCarId = car.id
+                dismiss()
+            } label: {
+                HStack(spacing: 16) {
+                    // 車のアイコン
+                    Text(car.emoji)
+                        .font(.system(size: 40))
+                        .frame(width: 60, height: 60)
+                        .background(Color(.systemGray6))
+                        .cornerRadius(12)
+
+                    // 車の情報
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(car.name)
+                            .font(.headline)
+                            .foregroundColor(.primary)
+                        Text(car.description)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+
+                    Spacer()
+
+                    // 選択状態
+                    if car.id == selectedCarId {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.blue)
+                            .font(.title3)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+        .navigationTitle("車を選択")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        CarSelectionView(selectedCarId: .constant("mini_cooper"))
+    }
+}

--- a/ios/Genesis/SettingsView.swift
+++ b/ios/Genesis/SettingsView.swift
@@ -14,6 +14,19 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             Form {
+                Section("車") {
+                    NavigationLink {
+                        CarSelectionView(selectedCarId: $settings.selectedCarId)
+                    } label: {
+                        HStack {
+                            Text("モデル")
+                            Spacer()
+                            Text("\(settings.selectedCar.emoji) \(settings.selectedCar.name)")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+
                 Section("操作") {
                     VStack(alignment: .leading) {
                         HStack {


### PR DESCRIPTION
## Summary
- 設定画面に「車」セクションを追加し、車選択画面へ遷移できるように
- 4車種のモックデータ（Mini Cooper、スポーツカー、SUV、トラック）
- 選択状態をUserDefaultsで永続化
- USDZモデル追加で車種拡張可能な構造

## Test plan
- [ ] 設定画面に「車 > モデル」が表示されること
- [ ] タップで車選択画面が開くこと
- [ ] 車を選択するとチェックマークが付き設定画面に戻ること
- [ ] アプリ再起動後も選択が保持されること

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)