### PR TITLE
操作系の刷新: ジョイスティック+アクセル/バックボタン

### DIFF
--- a/ios/Genesis/ARViewContainer.swift
+++ b/ios/Genesis/ARViewContainer.swift
@@ -5,8 +5,8 @@ import ARKit
 struct ARViewContainer: UIViewRepresentable {
     @Binding var isAccelerating: Bool
     @Binding var isBraking: Bool
-    @Binding var isTurningLeft: Bool
-    @Binding var isTurningRight: Bool
+    @Binding var steeringX: Double
+    @Binding var isReverse: Bool
     @Binding var hasPlacedCar: Bool
     @Binding var errorMessage: String?
     @Binding var currentSpeedRatio: Double
@@ -37,8 +37,8 @@ struct ARViewContainer: UIViewRepresentable {
     func updateUIView(_ uiView: ARView, context: Context) {
         context.coordinator.isAccelerating = isAccelerating
         context.coordinator.isBraking = isBraking
-        context.coordinator.isTurningLeft = isTurningLeft
-        context.coordinator.isTurningRight = isTurningRight
+        context.coordinator.steeringX = Float(steeringX)
+        context.coordinator.isReverse = isReverse
         context.coordinator.hasPlacedCarBinding = $hasPlacedCar
         context.coordinator.errorMessageBinding = $errorMessage
         context.coordinator.currentSpeedRatioBinding = $currentSpeedRatio
@@ -63,14 +63,10 @@ struct ARViewContainer: UIViewRepresentable {
         private var updateTimer: Timer?
         private var planeEntities: [ARAnchor: (AnchorEntity, ModelEntity)] = [:]
 
-        var isAccelerating: Bool = false {
-            didSet { updateSpeed() }
-        }
-        var isBraking: Bool = false {
-            didSet { updateSpeed() }
-        }
-        var isTurningLeft: Bool = false
-        var isTurningRight: Bool = false
+        var isAccelerating: Bool = false
+        var isBraking: Bool = false
+        var steeringX: Float = 0.0
+        var isReverse: Bool = false
 
         private var maxSpeed: Float { Float(AppSettings.shared.maxSpeed) }
         private var acceleration: Float { Float(AppSettings.shared.acceleration) }
@@ -213,42 +209,46 @@ struct ARViewContainer: UIViewRepresentable {
             }
         }
 
-        private func updateSpeed() {
-            if isAccelerating {
-                currentSpeed = min(currentSpeed + acceleration, maxSpeed)
-            } else if isBraking {
-                currentSpeed = max(currentSpeed - deceleration, 0)
-            } else {
-                currentSpeed = max(currentSpeed - deceleration * 0.5, 0)
-            }
-        }
-
         private func updateCarPosition() {
             guard let car = carEntity else { return }
 
-            updateSpeed()
+            // 速度の更新
+            let directionMultiplier: Float = isReverse ? -1.0 : 1.0
 
-            if isTurningLeft {
-                currentRotation += rotationSpeed
-            } else if isTurningRight {
-                currentRotation -= rotationSpeed
+            if isAccelerating || isReverse {
+                // アクセルまたはバックボタン押下中は加速
+                let limit = maxSpeed * (isReverse ? 0.5 : 1.0)
+                currentSpeed = min(currentSpeed + acceleration, limit)
+            } else {
+                // エンジンブレーキで自然に減速
+                currentSpeed = max(currentSpeed - deceleration * 0.5, 0)
+            }
+
+            // ステアリング（速度が出ているときのみ曲がれる）
+            if currentSpeed > 0.001 {
+                if steeringX < -0.3 {
+                    currentRotation += rotationSpeed * directionMultiplier
+                } else if steeringX > 0.3 {
+                    currentRotation -= rotationSpeed * directionMultiplier
+                }
             }
 
             let steeringRotation = simd_quatf(angle: currentRotation, axis: SIMD3<Float>(0, 1, 0))
             car.orientation = steeringRotation * modelUpCorrection
 
             // 速度比率をUIに通知
+            let maxSpeedForMode = maxSpeed * (isReverse ? 0.5 : 1.0)
             DispatchQueue.main.async {
-                self.currentSpeedRatioBinding?.wrappedValue = Double(self.currentSpeed / self.maxSpeed)
+                self.currentSpeedRatioBinding?.wrappedValue = Double(self.currentSpeed / maxSpeedForMode)
             }
 
-            if currentSpeed > 0 {
+            if currentSpeed > 0.001 {
                 let direction = SIMD3<Float>(
                     -sin(currentRotation),
                     0,
                     -cos(currentRotation)
                 )
-                let movement = direction * (currentSpeed / 60.0)
+                let movement = direction * (currentSpeed * directionMultiplier / 60.0)
                 car.position += movement
             }
         }

--- a/ios/Genesis/ContentView.swift
+++ b/ios/Genesis/ContentView.swift
@@ -2,27 +2,21 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var isAccelerating = false
+    @State private var isBraking = false
+    @State private var isReversing = false
     @State private var joystickX: Double = 0
     @State private var joystickY: Double = 0
     @State private var hasPlacedCar = false
     @State private var errorMessage: String?
     @State private var currentSpeedRatio: Double = 0
 
-    private var isTurningLeft: Bool {
-        joystickX < -0.3
-    }
-
-    private var isTurningRight: Bool {
-        joystickX > 0.3
-    }
-
     var body: some View {
         ZStack {
             ARViewContainer(
                 isAccelerating: $isAccelerating,
-                isBraking: .constant(false),
-                isTurningLeft: .constant(isTurningLeft),
-                isTurningRight: .constant(isTurningRight),
+                isBraking: $isBraking,
+                steeringX: $joystickX,
+                isReverse: $isReversing,
                 hasPlacedCar: $hasPlacedCar,
                 errorMessage: $errorMessage,
                 currentSpeedRatio: $currentSpeedRatio
@@ -48,37 +42,37 @@ struct ContentView: View {
                         .padding(.bottom, 8)
 
                     HStack(alignment: .bottom, spacing: 20) {
-                        // ジョイスティック
-                        Joystick(xAxis: $joystickX, yAxis: $joystickY)
+                        // ジョイスティック（ステアリング）+ 速度メーター
+                        VStack(spacing: 8) {
+                            SpeedMeter(speedRatio: currentSpeedRatio)
+                            Joystick(xAxis: $joystickX, yAxis: $joystickY)
+                        }
 
                         Spacer()
 
-                        // 速度メーター
-                        SpeedMeter(speedRatio: currentSpeedRatio)
-
-                        // アクセルボタン
-                        Button(action: {}) {
-                            ZStack {
-                                Circle()
-                                    .fill(isAccelerating
-                                        ? Color.green
-                                        : Color.green.opacity(0.4))
-                                    .frame(width: 100, height: 100)
-
-                                Circle()
-                                    .stroke(Color.white.opacity(0.4), lineWidth: 2)
-                                    .frame(width: 100, height: 100)
-
-                                Image(systemName: "arrow.up")
-                                    .font(.system(size: 32, weight: .bold))
-                                    .foregroundColor(.white)
+                        // アクセル + バック
+                        ZStack(alignment: .bottomLeading) {
+                            // アクセルボタン（大）
+                            PedalButton(
+                                icon: "arrow.up",
+                                color: .green,
+                                isPressed: isAccelerating,
+                                size: 110
+                            ) { pressed in
+                                isAccelerating = pressed
                             }
+
+                            // バックボタン（小・左下）
+                            PedalButton(
+                                icon: "arrow.uturn.backward",
+                                color: .orange,
+                                isPressed: isReversing,
+                                size: 56
+                            ) { pressed in
+                                isReversing = pressed
+                            }
+                            .offset(x: -50, y: 10)
                         }
-                        .simultaneousGesture(
-                            DragGesture(minimumDistance: 0)
-                                .onChanged { _ in isAccelerating = true }
-                                .onEnded { _ in isAccelerating = false }
-                        )
                     }
                     .padding(.horizontal, 30)
                     .padding(.bottom, 40)
@@ -93,6 +87,36 @@ struct ContentView: View {
         } message: {
             Text(errorMessage ?? "")
         }
+    }
+}
+
+/// アクセル/ブレーキ/バック用のペダルボタン
+struct PedalButton: View {
+    let icon: String
+    let color: Color
+    let isPressed: Bool
+    var size: CGFloat = 80
+    let onPressChanged: (Bool) -> Void
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(isPressed ? color : color.opacity(0.4))
+                .frame(width: size, height: size)
+
+            Circle()
+                .stroke(Color.white.opacity(0.4), lineWidth: 2)
+                .frame(width: size, height: size)
+
+            Image(systemName: icon)
+                .font(.system(size: size * 0.3, weight: .bold))
+                .foregroundColor(.white)
+        }
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in onPressChanged(true) }
+                .onEnded { _ in onPressChanged(false) }
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- ジョイスティックX軸でステアリング
- アクセルボタン（大）で前進、バックボタン（小・左下）で後退
- ブレーキ廃止、エンジンブレーキのみで自然に減速
- バック時のステアリング逆転で自然な挙動
- 速度メーターをジョイスティック上に配置
- PedalButtonコンポーネント（サイズ可変）

## Test plan
- [ ] アクセルボタンで前進すること
- [ ] バックボタンで後退すること（最大速度50%）
- [ ] ボタンを離すとエンブレで自然に減速すること
- [ ] バック中のステアリングが逆転すること
- [ ] ボタンのサイズ・配置が適切であること

Closes #1, Closes #2, Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)