### PR TITLE
平面検知UXの改善

### DIFF
--- a/ios/Genesis/ARViewContainer.swift
+++ b/ios/Genesis/ARViewContainer.swift
@@ -8,6 +8,7 @@ struct ARViewContainer: UIViewRepresentable {
     @Binding var steeringX: Double
     @Binding var isReverse: Bool
     @Binding var hasPlacedCar: Bool
+    @Binding var hasDetectedPlane: Bool
     @Binding var errorMessage: String?
     @Binding var currentSpeedRatio: Double
 
@@ -40,6 +41,7 @@ struct ARViewContainer: UIViewRepresentable {
         context.coordinator.steeringX = Float(steeringX)
         context.coordinator.isReverse = isReverse
         context.coordinator.hasPlacedCarBinding = $hasPlacedCar
+        context.coordinator.hasDetectedPlaneBinding = $hasDetectedPlane
         context.coordinator.errorMessageBinding = $errorMessage
         context.coordinator.currentSpeedRatioBinding = $currentSpeedRatio
     }
@@ -51,6 +53,7 @@ struct ARViewContainer: UIViewRepresentable {
     class Coordinator: NSObject, ARSessionDelegate {
         weak var arView: ARView?
         var hasPlacedCarBinding: Binding<Bool>?
+        var hasDetectedPlaneBinding: Binding<Bool>?
         var errorMessageBinding: Binding<String?>?
         var currentSpeedRatioBinding: Binding<Double>?
         private var hasPlacedCar = false
@@ -89,6 +92,7 @@ struct ARViewContainer: UIViewRepresentable {
         func session(_ session: ARSession, didAdd anchors: [ARAnchor]) {
             guard !hasPlacedCar, let arView = arView else { return }
 
+            var foundPlane = false
             for anchor in anchors {
                 guard let planeAnchor = anchor as? ARPlaneAnchor,
                       planeAnchor.alignment == .horizontal else { continue }
@@ -104,6 +108,15 @@ struct ARViewContainer: UIViewRepresentable {
                 arView.scene.addAnchor(anchorEntity)
 
                 planeEntities[anchor] = (anchorEntity, planeEntity)
+                foundPlane = true
+            }
+
+            // 初めて平面を検知した時に通知
+            if foundPlane, hasDetectedPlaneBinding?.wrappedValue == false {
+                DispatchQueue.main.async {
+                    self.hasDetectedPlaneBinding?.wrappedValue = true
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                }
             }
         }
 
@@ -146,8 +159,8 @@ struct ARViewContainer: UIViewRepresentable {
             let location = recognizer.location(in: arView)
             print("🔍 タップ位置: \(location)")
 
-            // レイキャストで平面上の位置を取得（検知済み平面 → 推定平面の順にフォールバック）
-            var results = arView.raycast(from: location, allowing: .existingPlaneGeometry, alignment: .horizontal)
+            // レイキャストで平面上の位置を取得（無限平面 → 推定平面の順にフォールバック）
+            var results = arView.raycast(from: location, allowing: .existingPlaneInfinite, alignment: .horizontal)
             if results.isEmpty {
                 results = arView.raycast(from: location, allowing: .estimatedPlane, alignment: .horizontal)
             }

--- a/ios/Genesis/ContentView.swift
+++ b/ios/Genesis/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
     @State private var joystickX: Double = 0
     @State private var joystickY: Double = 0
     @State private var hasPlacedCar = false
+    @State private var hasDetectedPlane = false
     @State private var errorMessage: String?
     @State private var currentSpeedRatio: Double = 0
 
@@ -19,6 +20,7 @@ struct ContentView: View {
                 steeringX: $joystickX,
                 isReverse: $isReversing,
                 hasPlacedCar: $hasPlacedCar,
+                hasDetectedPlane: $hasDetectedPlane,
                 errorMessage: $errorMessage,
                 currentSpeedRatio: $currentSpeedRatio
             )
@@ -44,15 +46,7 @@ struct ContentView: View {
 
                 // ステータステキスト
                 if !hasPlacedCar {
-                    Text("平面を検知中…タップで車を配置")
-                        .font(.headline)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 12)
-                        .background(Color.black.opacity(0.7))
-                        .foregroundColor(.white)
-                        .cornerRadius(10)
-                        .fixedSize(horizontal: false, vertical: true)
+                    PlaneDetectionStatusView(hasDetectedPlane: hasDetectedPlane)
                 }
                 Spacer()
 
@@ -108,6 +102,33 @@ struct ContentView: View {
         } message: {
             Text(errorMessage ?? "")
         }
+    }
+}
+
+// MARK: - 平面検知ステータス表示
+
+struct PlaneDetectionStatusView: View {
+    let hasDetectedPlane: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            if hasDetectedPlane {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(.green)
+                Text("平面を検知しました！タップして車を配置")
+            } else {
+                ProgressView()
+                    .tint(.white)
+                Text("平面を探しています...")
+            }
+        }
+        .font(.headline)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(Color.black.opacity(0.7))
+        .foregroundColor(.white)
+        .cornerRadius(10)
+        .animation(.easeInOut, value: hasDetectedPlane)
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #33

- 平面検知状態を2段階に分けて表示
  - スキャン中: スピナー＋「平面を探しています...」
  - 検知済み: チェックマーク＋「平面を検知しました！タップして車を配置」
- 平面検知時にハプティックフィードバックを追加
- レイキャストを`existingPlaneGeometry`→`existingPlaneInfinite`に変更してタップ成功率を改善

## Test plan

- [ ] 起動直後にスピナーと「平面を探しています...」が表示される
- [ ] 平面検知時にメッセージが切り替わりハプティックが鳴る
- [ ] 青いエリアをタップして車が配置される
- [ ] 以前より端の方でもタップが通るようになっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)