### PR TITLE
輸出コンプライアンスの自動化

### DIFF
--- a/ios/Genesis.xcodeproj/project.pbxproj
+++ b/ios/Genesis.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "AR Drive";
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "ARを使用して画像を認識し、3Dモデルを表示するためカメラが必要です。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -440,6 +441,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "AR Drive";
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "ARを使用して画像を認識し、3Dモデルを表示するためカメラが必要です。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;


### PR DESCRIPTION
## Summary

- `ITSAppUsesNonExemptEncryption = NO` を Debug・Release 両設定に追加
- これによりビルドアップロード時の「コンプライアンスがありません 管理」を自動解決

## Test plan

- [ ] Xcode でビルド確認
- [ ] App Store Connect にアップロードしてコンプライアンス確認が不要になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)