### PR TITLE
ドキュメントページとアーキテクチャドキュメントを追加

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,104 @@
+# Genesis アーキテクチャ
+
+## 概要
+
+Swift / SwiftUI で実装した iOS アプリ。ARKit + RealityKit で拡張現実を実現し、MVVM パターンで画面ロジックを管理する。
+
+---
+
+## 画面構成
+
+```
+GenesisApp
+└── TitleView（タイトル画面）
+    ├── DriveView（AR 操作画面）
+    │   ├── ARViewContainer（ARKit ラッパー）
+    │   ├── Joystick（操作スティック）
+    │   ├── SpeedMeter（速度メーター）
+    │   └── SteeringIndicator（ステアリング表示）
+    ├── CarSelectionView（車種選択画面）
+    └── SettingsView（設定画面）
+```
+
+---
+
+## ファイル構成
+
+```
+ios/Genesis/
+├── GenesisApp.swift              # アプリエントリーポイント
+├── AppSettings.swift             # 設定管理（シングルトン）
+├── CarModel.swift                # 車モデルの定義
+├── classicCar.usdz               # 3D モデル（Blender 製 USDC を usdzip で再パッケージ）
+├── Assets.xcassets/
+│   ├── AppIcon.appiconset/
+│   └── AR Resources.arresourcegroup/  # 画像認識用リファレンス画像
+└── Screen/
+    ├── Title/
+    │   ├── TitleView.swift
+    │   └── TitleViewModel.swift
+    ├── Drive/
+    │   ├── DriveView.swift
+    │   ├── DriveViewModel.swift
+    │   ├── ARViewContainer.swift  # UIViewRepresentable で ARView をラップ
+    │   ├── Joystick.swift
+    │   ├── SpeedMeter.swift
+    │   └── SteeringIndicator.swift
+    ├── CarSelection/
+    │   └── CarSelectionView.swift
+    └── Settings/
+        └── SettingsView.swift
+```
+
+---
+
+## アーキテクチャパターン
+
+**MVVM（Model - View - ViewModel）**
+
+| 役割 | クラス / ファイル |
+|---|---|
+| Model | `CarModel`, `AppSettings` |
+| View | `*View.swift`, `ARViewContainer.swift` |
+| ViewModel | `TitleViewModel`, `DriveViewModel` |
+
+- ViewModel は `@Observable` マクロを使用（Swift 5.9 以降）
+- `AppSettings` は `ObservableObject` のシングルトンで設定を全体に共有
+
+---
+
+## 主要コンポーネント
+
+### AppSettings
+- `UserDefaults` で設定値を永続化
+- ステアリング感度・最大速度・加速度・選択車種を管理
+- シングルトン（`AppSettings.shared`）
+
+### CarModel
+- 選択可能な車種を定義する値型（struct）
+- 現在実装済みモデル：クラシックカー（`classicCar.usdz`）
+- スポーツカー・SUV・トラックはデータのみ定義（モデルファイル未実装）
+
+### ARViewContainer
+- `UIViewRepresentable` で `ARView`（RealityKit）を SwiftUI にブリッジ
+- `ARWorldTrackingConfiguration` で水平面を検出
+- モデルの向き補正：X 軸 -90°（座標系変換）+ Y 軸 180°（モデル固有）
+- 移動方向の計算で `-sin(rotation)` を使用（モデルの前後に合わせた補正）
+
+### Joystick
+- 画面上の仮想スティック UI
+- X 軸でステアリング、Y 軸で前進 / 後退を制御
+
+---
+
+## 技術スタック
+
+| 項目 | 内容 |
+|---|---|
+| 言語 | Swift 5.9+ |
+| UI フレームワーク | SwiftUI |
+| AR フレームワーク | ARKit + RealityKit |
+| 3D モデル形式 | USDZ |
+| 設定永続化 | UserDefaults |
+| 最小サポート OS | iOS（ARKit 必須のため実機のみ） |
+| ビルド | Xcode（`ios/Genesis.xcodeproj`） |

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="ja">
+   <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Genesis - takoikatakotako</title>
+      <style>
+         body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            color: #333;
+            line-height: 1.7;
+            margin: 0;
+            padding: 0;
+            background: #fff;
+         }
+         .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 40px 20px;
+         }
+         h1 { font-size: 2rem; margin-bottom: 0.2em; }
+         h2 { font-size: 1.3rem; margin-top: 2em; border-bottom: 1px solid #e0e0e0; padding-bottom: 0.3em; }
+         ul { padding-left: 1.5em; }
+         li { margin-bottom: 0.5em; }
+         a { color: #007aff; text-decoration: none; }
+         a:hover { text-decoration: underline; }
+         .meta { color: #999; font-size: 0.9rem; }
+      </style>
+   </head>
+   <body>
+      <div class="container">
+         <h1>Genesis</h1>
+         <p class="meta">最終更新日: 2026年5月17日</p>
+
+         <h2>概要</h2>
+         <p>Genesis は ARKit を活用したラジコンカー操作 iOS アプリです。カメラをかざすだけで目の前の空間にクラシックカーが登場し、画面上のスティックで自由に操作できます。</p>
+
+         <h2>主な機能</h2>
+         <ul>
+            <li>ARKit による高精度な拡張現実体験</li>
+            <li>直感的な操作スティックでかんたん操作</li>
+            <li>かわいいクラシックカーのミニチュアモデル</li>
+            <li>リビング、公園、どこでも走れる</li>
+         </ul>
+
+         <h2>技術スタック</h2>
+         <ul>
+            <li><strong>Swift / SwiftUI</strong> - iOS アプリ開発</li>
+            <li><strong>ARKit + RealityKit</strong> - 拡張現実・3D レンダリング</li>
+            <li><strong>USDZ</strong> - 3D モデル形式</li>
+         </ul>
+
+         <h2>リンク</h2>
+         <ul>
+            <li><a href="https://github.com/takoikatakotako/Genesis" target="_blank">GitHub リポジトリ</a></li>
+            <li><a href="terms.html">利用規約</a></li>
+            <li><a href="privacy.html">プライバシーポリシー</a></li>
+            <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSeja6Km8Xz0vb_RlU1G1RO9URejXDO7cs2XyR7zu3ZR9fnAUg/viewform" target="_blank">お問い合わせ</a></li>
+         </ul>
+      </div>
+   </body>
+</html>


### PR DESCRIPTION
## Summary

- `docs/index.html` を追加（GitHub Pages のトップページ）
- `docs/architecture.md` を追加（画面構成・ファイル構成・MVVM パターン等）

## Test plan

- [ ] `https://takoikatakotako.github.io/Genesis/` でindex.html が表示される
- [ ] 利用規約・プライバシーポリシーへのリンクが正しく動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)