### PR TITLE
利用規約・プライバシーポリシーのサービス名をAR Driveに変更

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>Genesis プライバシーポリシー - takoikatakotako</title>
+      <title>AR Drive プライバシーポリシー - takoikatakotako</title>
       <style>
          body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
@@ -50,10 +50,10 @@
    <body>
       <div class="container">
          <div class="terms-section">
-            <h1>Genesis プライバシーポリシー</h1>
+            <h1>AR Drive プライバシーポリシー</h1>
             <p>最終更新日: 2026年5月14日</p>
 
-            <p>takoikatakotako（以下「当方」といいます）は、スマートフォン向けアプリケーションの開発を行っております。本アプリ「Genesis」（以下「本アプリ」といいます）をご利用いただくにあたり、以下のプライバシーポリシーをご確認ください。本アプリをご利用いただいた場合、本プライバシーポリシーに同意いただいたものとみなします。</p>
+            <p>takoikatakotako（以下「当方」といいます）は、スマートフォン向けアプリケーションの開発を行っております。本アプリ「AR Drive」（以下「本アプリ」といいます）をご利用いただくにあたり、以下のプライバシーポリシーをご確認ください。本アプリをご利用いただいた場合、本プライバシーポリシーに同意いただいたものとみなします。</p>
 
             <p>収集した情報は、サービスの提供および改善のために使用されます。</p>
 
@@ -84,7 +84,7 @@
             <h2>お問い合わせ</h2>
             <p>本プライバシーポリシーに関するお問い合わせは、以下までご連絡ください。</p>
             <ul>
-               <li>アプリ名: Genesis</li>
+               <li>アプリ名: AR Drive</li>
                <li>運営者: takoikatakotako</li>
                <li>お問い合わせ: <a href="https://docs.google.com/forms/d/e/1FAIpQLSeja6Km8Xz0vb_RlU1G1RO9URejXDO7cs2XyR7zu3ZR9fnAUg/viewform" target="_blank">お問い合わせフォーム</a></li>
             </ul>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>Genesis 利用規約 - takoikatakotako</title>
+      <title>AR Drive 利用規約 - takoikatakotako</title>
       <style>
          body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
@@ -50,10 +50,10 @@
    <body>
       <div class="container">
          <div class="terms-section">
-            <h1>Genesis 利用規約</h1>
+            <h1>AR Drive 利用規約</h1>
             <p>最終更新日: 2026年5月14日</p>
 
-            <p>本利用規約（以下「本規約」といいます）は、takoikatakotako（以下「当方」といいます）が提供するGenesis（以下「本アプリ」といいます）の利用条件を定めるものです。</p>
+            <p>本利用規約（以下「本規約」といいます）は、takoikatakotako（以下「当方」といいます）が提供するAR Drive（以下「本アプリ」といいます）の利用条件を定めるものです。</p>
 
             <h1>第1条（適用）</h1>
             <ol>
@@ -64,7 +64,7 @@
             <h1>第2条（定義）</h1>
             <p>本規約において使用する以下の用語は、各々以下に定める意味を有するものとします。</p>
             <ol>
-               <li>「本サービス」とは、当方が提供するGenesisという名称のサービス（理由の如何を問わずサービスの名称または内容が変更された場合は、当該変更後のサービスを含みます）を意味します。</li>
+               <li>「本サービス」とは、当方が提供するAR Driveという名称のサービス（理由の如何を問わずサービスの名称または内容が変更された場合は、当該変更後のサービスを含みます）を意味します。</li>
                <li>「ユーザー」とは、本規約に同意の上、本アプリを利用する全ての方を意味します。</li>
             </ol>
 
@@ -160,7 +160,7 @@
 
             <h2>運営者情報</h2>
             <ul>
-               <li>サービス名: Genesis</li>
+               <li>サービス名: AR Drive</li>
                <li>運営者: takoikatakotako</li>
                <li>お問い合わせ: <a href="https://docs.google.com/forms/d/e/1FAIpQLSeja6Km8Xz0vb_RlU1G1RO9URejXDO7cs2XyR7zu3ZR9fnAUg/viewform" target="_blank">お問い合わせフォーム</a></li>
             </ul>


### PR DESCRIPTION
## Summary

- 利用規約・プライバシーポリシー内の「Genesis」を App Store 表示名の「AR Drive」に統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)