### PR TITLE
AdMob広告とApp Tracking Transparencyの実装

### DIFF
--- a/ios/Genesis.xcconfig
+++ b/ios/Genesis.xcconfig
@@ -1,3 +1,5 @@
-// AdMob 広告ユニットID
-// 本番リリース時はProduction IDに差し替える
+// AdMob 本番バナー広告ユニットID
+// App Store本番配信時のみ使用される。
+// Debug ビルド・TestFlight 配信時は AdManager.testBannerAdUnitID が使われる。
+// 本番リリース前に Production ID に差し替える。
 ADMOB_BANNER_AD_UNIT_ID = ca-app-pub-3940256099942544/2934735716

--- a/ios/Genesis.xcconfig
+++ b/ios/Genesis.xcconfig
@@ -1,0 +1,3 @@
+// AdMob 広告ユニットID
+// 本番リリース時はProduction IDに差し替える
+ADMOB_BANNER_AD_UNIT_ID = ca-app-pub-3940256099942544/2934735716

--- a/ios/Genesis.xcconfig
+++ b/ios/Genesis.xcconfig
@@ -1,5 +1,4 @@
-// AdMob 本番バナー広告ユニットID
+// AdMob 本番バナー広告ユニットID（title-banner）
 // App Store本番配信時のみ使用される。
 // Debug ビルド・TestFlight 配信時は AdManager.testBannerAdUnitID が使われる。
-// 本番リリース前に Production ID に差し替える。
-ADMOB_BANNER_AD_UNIT_ID = ca-app-pub-3940256099942544/2934735716
+ADMOB_BANNER_AD_UNIT_ID = ca-app-pub-5587141252700968/8895674353

--- a/ios/Genesis.xcodeproj/project.pbxproj
+++ b/ios/Genesis.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		D6E60BE2620F43DE8082AD21 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 816E4B8D59CA4E3997F21EB1 /* GoogleMobileAds */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		178747002F6B092600FC69B7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -27,10 +31,11 @@
 		178746F22F6B092400FC69B7 /* Genesis.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Genesis.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		178746FF2F6B092600FC69B7 /* GenesisTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GenesisTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		178747092F6B092600FC69B7 /* GenesisUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GenesisUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A52A39716EC949B8B64BB5B9 /* Genesis.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Genesis.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		7EBF12606AD04174BFEB97C2 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		7EBF12606AD04174BFEB97C2 /* Exceptions for "Genesis" folder in "Genesis" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -43,7 +48,7 @@
 		178746F42F6B092400FC69B7 /* Genesis */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				7EBF12606AD04174BFEB97C2 /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
+				7EBF12606AD04174BFEB97C2 /* Exceptions for "Genesis" folder in "Genesis" target */,
 			);
 			path = Genesis;
 			sourceTree = "<group>";
@@ -65,6 +70,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D6E60BE2620F43DE8082AD21 /* GoogleMobileAds in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -88,6 +94,7 @@
 		178746E92F6B092400FC69B7 = {
 			isa = PBXGroup;
 			children = (
+				A52A39716EC949B8B64BB5B9 /* Genesis.xcconfig */,
 				178746F42F6B092400FC69B7 /* Genesis */,
 				178747022F6B092600FC69B7 /* GenesisTests */,
 				1787470C2F6B092600FC69B7 /* GenesisUITests */,
@@ -125,6 +132,7 @@
 			);
 			name = Genesis;
 			packageProductDependencies = (
+				816E4B8D59CA4E3997F21EB1 /* GoogleMobileAds */,
 			);
 			productName = Genesis;
 			productReference = 178746F22F6B092400FC69B7 /* Genesis.app */;
@@ -408,6 +416,7 @@
 		};
 		178747142F6B092600FC69B7 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A52A39716EC949B8B64BB5B9 /* Genesis.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -440,6 +449,7 @@
 		};
 		178747152F6B092600FC69B7 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A52A39716EC949B8B64BB5B9 /* Genesis.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -605,6 +615,14 @@
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		816E4B8D59CA4E3997F21EB1 /* GoogleMobileAds */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 175DCC422FBCBF1400A0D0BE /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
+			productName = GoogleMobileAds;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 178746EA2F6B092400FC69B7 /* Project object */;
 }

--- a/ios/Genesis.xcodeproj/project.pbxproj
+++ b/ios/Genesis.xcodeproj/project.pbxproj
@@ -29,9 +29,22 @@
 		178747092F6B092600FC69B7 /* GenesisUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GenesisUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		7EBF12606AD04174BFEB97C2 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 178746F12F6B092400FC69B7 /* Genesis */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		178746F42F6B092400FC69B7 /* Genesis */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				7EBF12606AD04174BFEB97C2 /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
+			);
 			path = Genesis;
 			sourceTree = "<group>";
 		};

--- a/ios/Genesis.xcodeproj/project.pbxproj
+++ b/ios/Genesis.xcodeproj/project.pbxproj
@@ -195,6 +195,9 @@
 			);
 			mainGroup = 178746E92F6B092400FC69B7;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				175DCC422FBCBF1400A0D0BE /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 178746F32F6B092400FC69B7 /* Products */;
 			projectDirPath = "";
@@ -399,16 +402,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 5RH346BQ66;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "AR Drive";
-				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
-				INFOPLIST_KEY_NSCameraUsageDescription = "ARを使用して画像を認識し、3Dモデルを表示するためカメラが必要です。";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_BackgroundColor = LaunchBackground;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Genesis/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -439,16 +434,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 5RH346BQ66;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "AR Drive";
-				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
-				INFOPLIST_KEY_NSCameraUsageDescription = "ARを使用して画像を認識し、3Dモデルを表示するためカメラが必要です。";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_BackgroundColor = LaunchBackground;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Genesis/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -594,6 +581,17 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		175DCC422FBCBF1400A0D0BE /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/googleads/swift-package-manager-google-mobile-ads";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 13.4.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
 	};
 	rootObject = 178746EA2F6B092400FC69B7 /* Project object */;
 }

--- a/ios/Genesis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Genesis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "a0e7c8e02f923b679180e347f7fdac90c95fc27903ff96ecee91f17a7815ce78",
+  "pins" : [
+    {
+      "identity" : "swift-package-manager-google-mobile-ads",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads",
+      "state" : {
+        "revision" : "a81f522aa4f59c0d90ee523d703bd426d5b27a03",
+        "version" : "13.4.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-user-messaging-platform",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
+      "state" : {
+        "revision" : "13b248eaa73b7826f0efb1bcf455e251d65ecb1b",
+        "version" : "3.1.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios/Genesis/AdManager.swift
+++ b/ios/Genesis/AdManager.swift
@@ -9,8 +9,23 @@ import GoogleMobileAds
 final class AdManager {
     static let shared = AdManager()
 
+    // Google公式のテスト用バナー広告ユニットID
+    private static let testBannerAdUnitID = "ca-app-pub-3940256099942544/2934735716"
+
     static var bannerAdUnitID: String {
-        Bundle.main.object(forInfoDictionaryKey: "AdMobBannerAdUnitID") as? String ?? ""
+        if shouldUseTestAds {
+            return testBannerAdUnitID
+        }
+        return Bundle.main.object(forInfoDictionaryKey: "AdMobBannerAdUnitID") as? String ?? testBannerAdUnitID
+    }
+
+    /// Debug ビルドまたは TestFlight 配信時は true。App Store 本番のみ false
+    private static var shouldUseTestAds: Bool {
+        #if DEBUG
+        return true
+        #else
+        return Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+        #endif
     }
 
     private var isStarted = false

--- a/ios/Genesis/AdManager.swift
+++ b/ios/Genesis/AdManager.swift
@@ -6,39 +6,23 @@
 import GoogleMobileAds
 
 @MainActor
-class AdManager: NSObject {
+final class AdManager {
     static let shared = AdManager()
 
     // テスト用ID。本番リリース時は実際の広告ユニットIDに差し替える
     #if DEBUG
     static let bannerAdUnitID = "ca-app-pub-3940256099942544/2934735716"
-    static let interstitialAdUnitID = "ca-app-pub-3940256099942544/4411468910"
     #else
     static let bannerAdUnitID = "YOUR_BANNER_AD_UNIT_ID"
-    static let interstitialAdUnitID = "YOUR_INTERSTITIAL_AD_UNIT_ID"
     #endif
 
-    private var interstitialAd: InterstitialAd?
+    private var isStarted = false
 
-    override private init() {
-        super.init()
-    }
+    private init() {}
 
-    func loadInterstitialAd() async {
-        do {
-            interstitialAd = try await InterstitialAd.load(
-                with: AdManager.interstitialAdUnitID,
-                request: Request()
-            )
-        } catch {
-            print("インタースティシャル広告のロード失敗: \(error)")
-        }
-    }
-
-    func showInterstitialAd(from viewController: UIViewController) {
-        guard let ad = interstitialAd else { return }
-        ad.present(from: viewController)
-        interstitialAd = nil
-        Task { await loadInterstitialAd() }
+    func startIfNeeded() {
+        guard !isStarted else { return }
+        isStarted = true
+        MobileAds.shared.start()
     }
 }

--- a/ios/Genesis/AdManager.swift
+++ b/ios/Genesis/AdManager.swift
@@ -9,12 +9,9 @@ import GoogleMobileAds
 final class AdManager {
     static let shared = AdManager()
 
-    // テスト用ID。本番リリース時は実際の広告ユニットIDに差し替える
-    #if DEBUG
-    static let bannerAdUnitID = "ca-app-pub-3940256099942544/2934735716"
-    #else
-    static let bannerAdUnitID = "YOUR_BANNER_AD_UNIT_ID"
-    #endif
+    static var bannerAdUnitID: String {
+        Bundle.main.object(forInfoDictionaryKey: "AdMobBannerAdUnitID") as? String ?? ""
+    }
 
     private var isStarted = false
 

--- a/ios/Genesis/AdManager.swift
+++ b/ios/Genesis/AdManager.swift
@@ -6,7 +6,7 @@
 import GoogleMobileAds
 
 @MainActor
-class AdManager: NSObject, ObservableObject {
+class AdManager: NSObject {
     static let shared = AdManager()
 
     // テスト用ID。本番リリース時は実際の広告ユニットIDに差し替える

--- a/ios/Genesis/AdManager.swift
+++ b/ios/Genesis/AdManager.swift
@@ -1,0 +1,44 @@
+//
+//  AdManager.swift
+//  Genesis
+//
+
+import GoogleMobileAds
+
+@MainActor
+class AdManager: NSObject, ObservableObject {
+    static let shared = AdManager()
+
+    // テスト用ID。本番リリース時は実際の広告ユニットIDに差し替える
+    #if DEBUG
+    static let bannerAdUnitID = "ca-app-pub-3940256099942544/2934735716"
+    static let interstitialAdUnitID = "ca-app-pub-3940256099942544/4411468910"
+    #else
+    static let bannerAdUnitID = "YOUR_BANNER_AD_UNIT_ID"
+    static let interstitialAdUnitID = "YOUR_INTERSTITIAL_AD_UNIT_ID"
+    #endif
+
+    private var interstitialAd: InterstitialAd?
+
+    override private init() {
+        super.init()
+    }
+
+    func loadInterstitialAd() async {
+        do {
+            interstitialAd = try await InterstitialAd.load(
+                with: AdManager.interstitialAdUnitID,
+                request: Request()
+            )
+        } catch {
+            print("インタースティシャル広告のロード失敗: \(error)")
+        }
+    }
+
+    func showInterstitialAd(from viewController: UIViewController) {
+        guard let ad = interstitialAd else { return }
+        ad.present(from: viewController)
+        interstitialAd = nil
+        Task { await loadInterstitialAd() }
+    }
+}

--- a/ios/Genesis/GenesisApp.swift
+++ b/ios/Genesis/GenesisApp.swift
@@ -6,12 +6,25 @@
 //
 
 import SwiftUI
+import GoogleMobileAds
+import AppTrackingTransparency
 
 @main
 struct GenesisApp: App {
+    init() {
+        MobileAds.shared.start()
+    }
+
     var body: some Scene {
         WindowGroup {
             TitleView()
+                .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+                    requestTrackingAuthorization()
+                }
         }
+    }
+
+    private func requestTrackingAuthorization() {
+        ATTrackingManager.requestTrackingAuthorization { _ in }
     }
 }

--- a/ios/Genesis/GenesisApp.swift
+++ b/ios/Genesis/GenesisApp.swift
@@ -6,25 +6,22 @@
 //
 
 import SwiftUI
-import GoogleMobileAds
 import AppTrackingTransparency
 
 @main
 struct GenesisApp: App {
-    init() {
-        MobileAds.shared.start()
-    }
-
     var body: some Scene {
         WindowGroup {
             TitleView()
-                .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
-                    requestTrackingAuthorization()
+                .task {
+                    await requestTrackingAuthorizationIfNeeded()
+                    AdManager.shared.startIfNeeded()
                 }
         }
     }
 
-    private func requestTrackingAuthorization() {
-        ATTrackingManager.requestTrackingAuthorization { _ in }
+    private func requestTrackingAuthorizationIfNeeded() async {
+        guard ATTrackingManager.trackingAuthorizationStatus == .notDetermined else { return }
+        _ = await ATTrackingManager.requestTrackingAuthorization()
     }
 }

--- a/ios/Genesis/GenesisApp.swift
+++ b/ios/Genesis/GenesisApp.swift
@@ -10,13 +10,22 @@ import AppTrackingTransparency
 
 @main
 struct GenesisApp: App {
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var hasRequestedATT = false
+
     var body: some Scene {
         WindowGroup {
             TitleView()
-                .task {
-                    await requestTrackingAuthorizationIfNeeded()
-                    AdManager.shared.startIfNeeded()
-                }
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            guard newPhase == .active, !hasRequestedATT else { return }
+            hasRequestedATT = true
+            Task {
+                // ATTダイアログはscene activeになり切ってから呼ばないと無音で失敗するため少し待つ
+                try? await Task.sleep(for: .milliseconds(500))
+                await requestTrackingAuthorizationIfNeeded()
+                AdManager.shared.startIfNeeded()
+            }
         }
     }
 

--- a/ios/Genesis/Info.plist
+++ b/ios/Genesis/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>AR Drive</string>
+    <key>GADApplicationIdentifier</key>
+    <string>ca-app-pub-3940256099942544~1458002511</string>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
+    <key>NSCameraUsageDescription</key>
+    <string>ARを使用して画像を認識し、3Dモデルを表示するためカメラが必要です。</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>より関連性の高い広告を表示するために使用されます。</string>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
+    <key>UIApplicationSupportsIndirectInputEvents</key>
+    <true/>
+    <key>UILaunchScreen</key>
+    <dict>
+        <key>UIColorName</key>
+        <string>LaunchBackground</string>
+    </dict>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+</dict>
+</plist>

--- a/ios/Genesis/Info.plist
+++ b/ios/Genesis/Info.plist
@@ -25,7 +25,7 @@
     <key>NSCameraUsageDescription</key>
     <string>ARを使用して画像を認識し、3Dモデルを表示するためカメラが必要です。</string>
     <key>NSUserTrackingUsageDescription</key>
-    <string>より関連性の高い広告を表示するために使用されます。</string>
+    <string>広告ID（IDFA）を使用して、お客様の興味に合った広告を表示します。許可しない場合も広告は表示されますが、内容の最適化が行われません。</string>
     <key>UIApplicationSceneManifest</key>
     <dict>
         <key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/Genesis/Info.plist
+++ b/ios/Genesis/Info.plist
@@ -21,7 +21,7 @@
     <key>AdMobBannerAdUnitID</key>
     <string>$(ADMOB_BANNER_AD_UNIT_ID)</string>
     <key>GADApplicationIdentifier</key>
-    <string>ca-app-pub-3940256099942544~1458002511</string>
+    <string>ca-app-pub-5587141252700968~8488480240</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <key>NSCameraUsageDescription</key>

--- a/ios/Genesis/Info.plist
+++ b/ios/Genesis/Info.plist
@@ -4,6 +4,20 @@
 <dict>
     <key>CFBundleDisplayName</key>
     <string>AR Drive</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>GADApplicationIdentifier</key>
     <string>ca-app-pub-3940256099942544~1458002511</string>
     <key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/Genesis/Info.plist
+++ b/ios/Genesis/Info.plist
@@ -18,6 +18,8 @@
     <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
     <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>AdMobBannerAdUnitID</key>
+    <string>$(ADMOB_BANNER_AD_UNIT_ID)</string>
     <key>GADApplicationIdentifier</key>
     <string>ca-app-pub-3940256099942544~1458002511</string>
     <key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/Genesis/Screen/Drive/DriveView.swift
+++ b/ios/Genesis/Screen/Drive/DriveView.swift
@@ -22,7 +22,7 @@ struct DriveView: View {
                 // 戻るボタン
                 HStack {
                     Button {
-                        showInterstitialAndDismiss()
+                        dismiss()
                     } label: {
                         Image(systemName: "xmark")
                             .font(.system(size: 16, weight: .semibold))
@@ -86,9 +86,6 @@ struct DriveView: View {
                 }
             }
         }
-        .task {
-            await AdManager.shared.loadInterstitialAd()
-        }
         .alert("エラー", isPresented: Binding(
             get: { viewModel.errorMessage != nil },
             set: { if !$0 { viewModel.clearError() } }
@@ -97,17 +94,6 @@ struct DriveView: View {
         } message: {
             Text(viewModel.errorMessage ?? "")
         }
-    }
-
-    private func showInterstitialAndDismiss() {
-        guard let rootVC = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .first?.windows.first?.rootViewController else {
-            dismiss()
-            return
-        }
-        AdManager.shared.showInterstitialAd(from: rootVC)
-        dismiss()
     }
 }
 

--- a/ios/Genesis/Screen/Drive/DriveView.swift
+++ b/ios/Genesis/Screen/Drive/DriveView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import GoogleMobileAds
 
 struct DriveView: View {
     @Environment(\.dismiss) private var dismiss
@@ -22,7 +23,7 @@ struct DriveView: View {
                 // 戻るボタン
                 HStack {
                     Button {
-                        dismiss()
+                        showInterstitialAndDismiss()
                     } label: {
                         Image(systemName: "xmark")
                             .font(.system(size: 16, weight: .semibold))
@@ -86,6 +87,9 @@ struct DriveView: View {
                 }
             }
         }
+        .task {
+            await AdManager.shared.loadInterstitialAd()
+        }
         .alert("エラー", isPresented: Binding(
             get: { viewModel.errorMessage != nil },
             set: { if !$0 { viewModel.clearError() } }
@@ -94,6 +98,17 @@ struct DriveView: View {
         } message: {
             Text(viewModel.errorMessage ?? "")
         }
+    }
+
+    private func showInterstitialAndDismiss() {
+        guard let rootVC = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first?.windows.first?.rootViewController else {
+            dismiss()
+            return
+        }
+        AdManager.shared.showInterstitialAd(from: rootVC)
+        dismiss()
     }
 }
 

--- a/ios/Genesis/Screen/Drive/DriveView.swift
+++ b/ios/Genesis/Screen/Drive/DriveView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import GoogleMobileAds
 
 struct DriveView: View {
     @Environment(\.dismiss) private var dismiss

--- a/ios/Genesis/Screen/Title/TitleView.swift
+++ b/ios/Genesis/Screen/Title/TitleView.swift
@@ -99,10 +99,10 @@ struct TitleView: View {
                 .position(x: geo.size.width / 2, y: geo.size.height * 0.88)
                 .opacity(viewModel.buttonOpacity)
 
-                // バナー広告（ドライブスタートボタンの上）
+                // バナー広告（ドライブスタートボタンの下）
                 BannerAdView(adUnitID: AdManager.bannerAdUnitID)
                     .frame(height: 50)
-                    .position(x: geo.size.width / 2, y: geo.size.height * 0.88 - 56 - 16)
+                    .position(x: geo.size.width / 2, y: geo.size.height * 0.88 + 56 / 2 + 16 + 25)
                     .opacity(viewModel.buttonOpacity)
             }
         }

--- a/ios/Genesis/Screen/Title/TitleView.swift
+++ b/ios/Genesis/Screen/Title/TitleView.swift
@@ -12,6 +12,12 @@ import GoogleMobileAds
 struct TitleView: View {
     @State private var viewModel = TitleViewModel()
 
+    private var bottomSafeAreaInset: CGFloat {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.windows.first?.safeAreaInsets.bottom ?? 0
+    }
+
     var body: some View {
         GeometryReader { geo in
             ZStack(alignment: .top) {
@@ -97,13 +103,13 @@ struct TitleView: View {
                     )
                 }
                 // ボタン中心 = バナー上端 - 余白16 - ボタン半分28
-                .position(x: geo.size.width / 2, y: geo.size.height - geo.safeAreaInsets.bottom - 50 - 16 - 28)
+                .position(x: geo.size.width / 2, y: geo.size.height - bottomSafeAreaInset - 50 - 16 - 28)
                 .opacity(viewModel.buttonOpacity)
 
                 // バナー広告（Safe Area直上）
                 BannerAdView(adUnitID: AdManager.bannerAdUnitID)
                     .frame(height: 50)
-                    .position(x: geo.size.width / 2, y: geo.size.height - geo.safeAreaInsets.bottom - 25)
+                    .position(x: geo.size.width / 2, y: geo.size.height - bottomSafeAreaInset - 25)
                     .opacity(viewModel.buttonOpacity)
             }
         }

--- a/ios/Genesis/Screen/Title/TitleView.swift
+++ b/ios/Genesis/Screen/Title/TitleView.swift
@@ -191,6 +191,7 @@ struct BannerAdView: UIViewRepresentable {
         bannerView.rootViewController = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
             .first?.windows.first?.rootViewController
+        bannerView.backgroundColor = .clear
         bannerView.load(Request())
         return bannerView
     }

--- a/ios/Genesis/Screen/Title/TitleView.swift
+++ b/ios/Genesis/Screen/Title/TitleView.swift
@@ -99,10 +99,10 @@ struct TitleView: View {
                 .position(x: geo.size.width / 2, y: geo.size.height * 0.88)
                 .opacity(viewModel.buttonOpacity)
 
-                // バナー広告（ドライブスタートボタンの下）
+                // バナー広告（Safe Area直上）
                 BannerAdView(adUnitID: AdManager.bannerAdUnitID)
                     .frame(height: 50)
-                    .position(x: geo.size.width / 2, y: geo.size.height * 0.88 + 56 / 2 + 16 + 25)
+                    .position(x: geo.size.width / 2, y: geo.size.height - geo.safeAreaInsets.bottom - 25)
                     .opacity(viewModel.buttonOpacity)
             }
         }

--- a/ios/Genesis/Screen/Title/TitleView.swift
+++ b/ios/Genesis/Screen/Title/TitleView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import SceneKit
+import GoogleMobileAds
 
 struct TitleView: View {
     @State private var viewModel = TitleViewModel()
@@ -97,6 +98,13 @@ struct TitleView: View {
                 }
                 .position(x: geo.size.width / 2, y: geo.size.height * 0.88)
                 .opacity(viewModel.buttonOpacity)
+
+                // バナー広告（最下部）
+                VStack {
+                    Spacer()
+                    BannerAdView(adUnitID: AdManager.bannerAdUnitID)
+                        .frame(height: 50)
+                }
             }
         }
         .ignoresSafeArea()
@@ -166,6 +174,22 @@ struct CarPreviewView: UIViewRepresentable {
         scnView.scene = scene
         scnView.pointOfView = cameraNode
     }
+}
+
+struct BannerAdView: UIViewRepresentable {
+    let adUnitID: String
+
+    func makeUIView(context: Context) -> BannerView {
+        let bannerView = BannerView(adSize: AdSizeBanner)
+        bannerView.adUnitID = adUnitID
+        bannerView.rootViewController = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.windows.first?.rootViewController
+        bannerView.load(Request())
+        return bannerView
+    }
+
+    func updateUIView(_ uiView: BannerView, context: Context) {}
 }
 
 #Preview {

--- a/ios/Genesis/Screen/Title/TitleView.swift
+++ b/ios/Genesis/Screen/Title/TitleView.swift
@@ -99,12 +99,11 @@ struct TitleView: View {
                 .position(x: geo.size.width / 2, y: geo.size.height * 0.88)
                 .opacity(viewModel.buttonOpacity)
 
-                // バナー広告（最下部）
-                VStack {
-                    Spacer()
-                    BannerAdView(adUnitID: AdManager.bannerAdUnitID)
-                        .frame(height: 50)
-                }
+                // バナー広告（ドライブスタートボタンの上）
+                BannerAdView(adUnitID: AdManager.bannerAdUnitID)
+                    .frame(height: 50)
+                    .position(x: geo.size.width / 2, y: geo.size.height * 0.88 - 56 - 16)
+                    .opacity(viewModel.buttonOpacity)
             }
         }
         .ignoresSafeArea()

--- a/ios/Genesis/Screen/Title/TitleView.swift
+++ b/ios/Genesis/Screen/Title/TitleView.swift
@@ -96,7 +96,8 @@ struct TitleView: View {
                             .fill(Color(red: 0.85, green: 0.45, blue: 0.5))
                     )
                 }
-                .position(x: geo.size.width / 2, y: geo.size.height * 0.88)
+                // ボタン中心 = バナー上端 - 余白16 - ボタン半分28
+                .position(x: geo.size.width / 2, y: geo.size.height - geo.safeAreaInsets.bottom - 50 - 16 - 28)
                 .opacity(viewModel.buttonOpacity)
 
                 // バナー広告（Safe Area直上）


### PR DESCRIPTION
closes #41

## 概要

AdMob バナー広告を実装し、App Tracking Transparency (ATT) 許可フローを追加。
App Store審査リジェクト（Guideline 5.1.2(i)）の対応を兼ねる。

## 変更内容

- `Info.plist` 新規作成（`GADApplicationIdentifier` ・`NSUserTrackingUsageDescription` ・`AdMobBannerAdUnitID` を追加）
- `project.pbxproj` — Info.plistを手動管理に切り替え、GoogleMobileAdsをターゲットにリンク、xcconfigを参照するよう設定
- `Genesis.xcconfig` 新規作成 — 本番バナー広告ユニットIDを外部から注入できる仕組み
- `AdManager.swift` 新規作成 — SDK初期化を管理。Debug / TestFlight ではテスト広告、App Store 本番のみ xcconfig の本番IDを使用（`appStoreReceiptURL` でランタイム判定）
- `GenesisApp.swift` — ATT 許可ステータスを確認し、未決定時のみ許可リクエスト → 完了後に SDK 初期化
- `TitleView.swift` — タイトル画面 Safe Area 直上にバナー広告を配置（背景透明）

## テスト項目

- [x] ビルドが通ること
- [x] 初回起動時に ATT 許可ダイアログが表示されること
- [x] タイトル画面の Safe Area 直上にバナー広告が表示されること
- [x] iPhone 15 で Safe Area に被らず正しく配置されること
- [ ] TestFlight 配信時にテスト広告が表示されること

## 本番リリースに向けて

- App Store 本番配信時は `Genesis.xcconfig` の `ADMOB_BANNER_AD_UNIT_ID` が読まれる
- 本番リリース前の最終確認として App Store Connect のプライバシー情報（Tracking 申告）を AdMob 仕様に合わせて更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)