### PR TITLE
AR Drive LP を作成（Issue #43）

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,60 +3,264 @@
    <head>
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>Genesis - takoikatakotako</title>
+      <title>AR Drive - ARラジコンカー iOS アプリ</title>
+      <meta name="description" content="AR Drive は ARKit を使った iOS 向けラジコンカーアプリ。カメラをかざすだけで、目の前の空間にクラシックカーが現れます。">
+
+      <meta property="og:title" content="AR Drive - ARラジコンカー iOS アプリ">
+      <meta property="og:description" content="ARKit を使った iOS 向けラジコンカーアプリ。カメラをかざすだけで、目の前の空間にクラシックカーが現れます。">
+      <meta property="og:type" content="website">
+      <meta property="og:url" content="https://takoikatakotako.github.io/Genesis/">
+
       <style>
+         :root {
+            --text: #1d1d1f;
+            --text-secondary: #6e6e73;
+            --bg: #ffffff;
+            --bg-alt: #f5f5f7;
+            --accent: #0071e3;
+            --border: #d2d2d7;
+         }
+
+         * { margin: 0; padding: 0; box-sizing: border-box; }
+
+         html { scroll-behavior: smooth; }
+
          body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-            color: #333;
-            line-height: 1.7;
-            margin: 0;
-            padding: 0;
-            background: #fff;
+            font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text",
+                         "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+            color: var(--text);
+            line-height: 1.6;
+            background: var(--bg);
+            -webkit-font-smoothing: antialiased;
          }
-         .container {
-            max-width: 800px;
-            margin: 0 auto;
-            padding: 40px 20px;
-         }
-         h1 { font-size: 2rem; margin-bottom: 0.2em; }
-         h2 { font-size: 1.3rem; margin-top: 2em; border-bottom: 1px solid #e0e0e0; padding-bottom: 0.3em; }
-         ul { padding-left: 1.5em; }
-         li { margin-bottom: 0.5em; }
-         a { color: #007aff; text-decoration: none; }
+
+         a { color: var(--accent); text-decoration: none; }
          a:hover { text-decoration: underline; }
-         .meta { color: #999; font-size: 0.9rem; }
+
+         /* Hero */
+         .hero {
+            text-align: center;
+            padding: 100px 24px 80px;
+            background: var(--bg);
+         }
+
+         .hero h1 {
+            font-size: clamp(2.5rem, 6vw, 4rem);
+            font-weight: 700;
+            letter-spacing: -0.02em;
+            margin-bottom: 16px;
+         }
+
+         .hero .tagline {
+            font-size: clamp(1.1rem, 2.5vw, 1.5rem);
+            color: var(--text-secondary);
+            font-weight: 400;
+            margin-bottom: 40px;
+            max-width: 640px;
+            margin-left: auto;
+            margin-right: auto;
+         }
+
+         .app-store-badge {
+            display: inline-block;
+            transition: transform 0.2s ease;
+         }
+
+         .app-store-badge:hover {
+            transform: scale(1.03);
+            text-decoration: none;
+         }
+
+         .app-store-badge img {
+            height: 56px;
+            vertical-align: middle;
+         }
+
+         /* Section */
+         section {
+            padding: 80px 24px;
+         }
+
+         section.alt {
+            background: var(--bg-alt);
+         }
+
+         .section-inner {
+            max-width: 980px;
+            margin: 0 auto;
+         }
+
+         h2 {
+            font-size: clamp(1.8rem, 4vw, 2.5rem);
+            font-weight: 600;
+            letter-spacing: -0.01em;
+            text-align: center;
+            margin-bottom: 16px;
+         }
+
+         .section-lead {
+            text-align: center;
+            color: var(--text-secondary);
+            font-size: 1.1rem;
+            margin-bottom: 56px;
+            max-width: 640px;
+            margin-left: auto;
+            margin-right: auto;
+         }
+
+         /* Features */
+         .features {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 32px;
+         }
+
+         .feature {
+            background: var(--bg);
+            padding: 32px;
+            border-radius: 18px;
+            text-align: left;
+         }
+
+         section.alt .feature {
+            background: var(--bg);
+         }
+
+         .feature-icon {
+            font-size: 2.5rem;
+            margin-bottom: 16px;
+            display: block;
+         }
+
+         .feature h3 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-bottom: 8px;
+         }
+
+         .feature p {
+            color: var(--text-secondary);
+            font-size: 0.95rem;
+         }
+
+         /* Requirements */
+         .req-list {
+            max-width: 560px;
+            margin: 0 auto;
+            background: var(--bg);
+            padding: 32px;
+            border-radius: 18px;
+         }
+
+         .req-list dl {
+            display: grid;
+            grid-template-columns: max-content 1fr;
+            gap: 12px 24px;
+         }
+
+         .req-list dt {
+            font-weight: 600;
+            color: var(--text);
+         }
+
+         .req-list dd {
+            color: var(--text-secondary);
+         }
+
+         /* Footer */
+         footer {
+            background: var(--bg-alt);
+            padding: 40px 24px;
+            border-top: 1px solid var(--border);
+            text-align: center;
+            font-size: 0.875rem;
+            color: var(--text-secondary);
+         }
+
+         footer .links {
+            margin-bottom: 16px;
+            display: flex;
+            justify-content: center;
+            gap: 24px;
+            flex-wrap: wrap;
+         }
+
+         footer .copyright {
+            color: var(--text-secondary);
+         }
+
+         @media (max-width: 600px) {
+            .hero { padding: 60px 20px 50px; }
+            section { padding: 60px 20px; }
+            .feature { padding: 24px; }
+            footer .links { gap: 16px; }
+         }
       </style>
    </head>
    <body>
-      <div class="container">
-         <h1>Genesis</h1>
-         <p class="meta">最終更新日: 2026年5月17日</p>
+      <!-- Hero -->
+      <section class="hero">
+         <h1>AR Drive</h1>
+         <p class="tagline">カメラをかざすだけで、目の前にクラシックカー。<br>AR で楽しむ、新しいラジコン体験。</p>
+         <a href="https://apps.apple.com/us/app/ar-drive/id6766765073" class="app-store-badge" target="_blank" rel="noopener">
+            <img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" alt="App Store からダウンロード">
+         </a>
+      </section>
 
-         <h2>概要</h2>
-         <p>Genesis は ARKit を活用したラジコンカー操作 iOS アプリです。カメラをかざすだけで目の前の空間にクラシックカーが登場し、画面上のスティックで自由に操作できます。</p>
+      <!-- Features -->
+      <section class="alt" id="features">
+         <div class="section-inner">
+            <h2>特徴</h2>
+            <p class="section-lead">スマホ1台で、どこでもラジコン遊びができます。</p>
+            <div class="features">
+               <div class="feature">
+                  <span class="feature-icon">📱</span>
+                  <h3>ARKit 対応</h3>
+                  <p>カメラをかざすだけで、空間にクラシックカーが現れます。専用デバイスや特別な準備は不要です。</p>
+               </div>
+               <div class="feature">
+                  <span class="feature-icon">🎮</span>
+                  <h3>直感的な操作</h3>
+                  <p>画面上のスティックで、車を自由に動かせます。前進・後退・旋回もスムーズに。</p>
+               </div>
+               <div class="feature">
+                  <span class="feature-icon">🚗</span>
+                  <h3>こだわりのモデル</h3>
+                  <p>かわいいクラシックカーの 3D モデルを用意。リビング・公園・どこでも走らせて楽しめます。</p>
+               </div>
+            </div>
+         </div>
+      </section>
 
-         <h2>主な機能</h2>
-         <ul>
-            <li>ARKit による高精度な拡張現実体験</li>
-            <li>直感的な操作スティックでかんたん操作</li>
-            <li>かわいいクラシックカーのミニチュアモデル</li>
-            <li>リビング、公園、どこでも走れる</li>
-         </ul>
+      <!-- Requirements -->
+      <section id="requirements">
+         <div class="section-inner">
+            <h2>必要環境</h2>
+            <p class="section-lead">ARKit 対応の iOS デバイスでご利用いただけます。</p>
+            <div class="req-list">
+               <dl>
+                  <dt>対応 OS</dt>
+                  <dd>iOS 26.2 以降</dd>
+                  <dt>対応デバイス</dt>
+                  <dd>ARKit 対応の iPhone / iPad</dd>
+                  <dt>必要権限</dt>
+                  <dd>カメラ（AR 表示のため）</dd>
+                  <dt>価格</dt>
+                  <dd>無料（広告表示あり）</dd>
+               </dl>
+            </div>
+         </div>
+      </section>
 
-         <h2>技術スタック</h2>
-         <ul>
-            <li><strong>Swift / SwiftUI</strong> - iOS アプリ開発</li>
-            <li><strong>ARKit + RealityKit</strong> - 拡張現実・3D レンダリング</li>
-            <li><strong>USDZ</strong> - 3D モデル形式</li>
-         </ul>
-
-         <h2>リンク</h2>
-         <ul>
-            <li><a href="https://github.com/takoikatakotako/Genesis" target="_blank">GitHub リポジトリ</a></li>
-            <li><a href="terms.html">利用規約</a></li>
-            <li><a href="privacy.html">プライバシーポリシー</a></li>
-            <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSeja6Km8Xz0vb_RlU1G1RO9URejXDO7cs2XyR7zu3ZR9fnAUg/viewform" target="_blank">お問い合わせ</a></li>
-         </ul>
-      </div>
+      <!-- Footer -->
+      <footer>
+         <div class="links">
+            <a href="terms.html">利用規約</a>
+            <a href="privacy.html">プライバシーポリシー</a>
+            <a href="https://docs.google.com/forms/d/e/1FAIpQLSeja6Km8Xz0vb_RlU1G1RO9URejXDO7cs2XyR7zu3ZR9fnAUg/viewform" target="_blank" rel="noopener">お問い合わせ</a>
+            <a href="https://github.com/takoikatakotako/Genesis" target="_blank" rel="noopener">GitHub</a>
+         </div>
+         <p class="copyright">© takoikatakotako</p>
+      </footer>
    </body>
 </html>


### PR DESCRIPTION
## 概要

[Issue #43](https://github.com/takoikatakotako/Genesis/issues/43) の一部として、`docs/index.html` を AR Drive のエンドユーザー向け LP に刷新。

`https://takoikatakotako.github.io/Genesis/` で公開され、App Store Connect の **マーケティング URL** に設定する想定。

## 変更内容

`docs/index.html` をシンプル/Apple風のクリーンなデザインで再構成:

- **ヒーロー**: タイトル + キャッチコピー + App Store ダウンロードバッジ
- **特徴**: ARKit対応 / 直感操作 / こだわりのモデル の3カラム
- **必要環境**: iOS 26.2 以降 / ARKit対応デバイス / カメラ権限 / 無料（広告あり）
- **フッター**: 利用規約 / プライバシーポリシー / 問い合わせ / GitHub

OG タグも追加してシェア時の見栄えも対応。

## プレビュー

ローカルで `python3 -m http.server --directory docs` で確認済み。

## 関連タスク（別 PR / 手動作業）

- [ ] `takoikatakotako.github.io` リポジトリのルートに `app-ads.txt` を配置（別 PR で対応予定）
- [ ] App Store Connect で マーケティング URL を `https://takoikatakotako.github.io/Genesis/` に設定
- [ ] AdMob 管理画面で app-ads.txt の再クロールをリクエスト

Refs #43